### PR TITLE
Internal flag to operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,41 @@ Or install it yourself as:
 ## Usage
 
 LedgerSync comes with 3 components.
+0. Registration
 1. Resource
 2. Serializers
 3. Operations
+
+### Register your engines
+
+`LedgerSync::Domains` requires little configuration so it can properly pick up domains and their namespace. While `LedgerSync::Domains` is not required to be used with Rails, it is the most expected usecase. THe problem with Rails (and possibly other codebases) is that the `MainApp` does not have a module namespace and referencing it from other domain operations is not as simple. There are two methods to help you register.
+
+#### Register your Main App
+
+`register_main_domain` creates a domain with name `:main` without any `base_module`. This way you can reference `MainApp` as `domain: :main` and serializers/operations will be picked up from there.
+
+```ruby
+# config/application.rb
+module DropBot
+  class Application < Rails::Application
+    LedgerSync::Domains.register_main_domain
+    # ...
+  end
+end
+```
+
+#### Register your Engine
+
+`register_domain` creates a domain with your own `name` and your own `base_module`. Lets say you place your engines under `engines` folder and you just created `billing` engine. To register it as a domain, update your `engine.rb` file. After that use it in your operations as `domain: :engine`. You can pass in string or symbol.
+```ruby
+# engines/billing/lib/billing/engine.rb
+module Billing
+  class Engine < ::Rails::Engine
+    isolate_namespace Billing
+    LedgerSync::Domains.register_domain(:billing, base_module: Billing)
+  end
+end
+```
 
 ### Resource/Model
 

--- a/README.md
+++ b/README.md
@@ -223,6 +223,22 @@ irb(main):003:0> op.result.value
 
 And thats it. Now you can use `LedgerSync` to define operations and have their results serialized against specific domain you are requesting it from.
 
+#### Internal operations
+
+Sometimes you want to create operation, that is not accessible from the rest of the app. The nature of ruby allows all defined classes be accessible from everywhere. To prevent execution of an operation from different domain, use `internal` flag when defining class.
+
+```ruby
+module Auth
+  module Users
+    class FindOperation < LedgerSync::Domains::Operation::Find
+      internal
+    end
+  end
+end
+```
+
+When performing an operation there are series of guards. First one validates if operation is allowed to be executed. That means either it is not flagged as internal operation, or target domain is same domain as module operation is defined in. If operation is not allowed to be executed, failure is returned with `LedgerSync::Domains::InternalOperationError` error.
+
 ### Cross-domain relationships
 
 One important note about relationships. Splitting your app into multiple engines is eventually gonna lead to your ActiveRecord Models to have relationships that reference Models from other engines. There are two ways how to look at this issue.

--- a/lib/ledger_sync/domains.rb
+++ b/lib/ledger_sync/domains.rb
@@ -2,6 +2,7 @@
 
 require 'ledger_sync'
 require_relative 'domains/version'
+require_relative 'domains/store'
 require_relative 'domains/serializer'
 require_relative 'domains/operation'
 require_relative 'domains/operation/add'
@@ -12,5 +13,23 @@ require_relative 'domains/operation/transition'
 require_relative 'domains/operation/update'
 
 module LedgerSync
-  module Domains; end
+  module Domains
+    def self.domains
+      @domains ||= LedgerSync::Domains::ConfigurationStore.new
+    end
+
+    def self.register_domain(*args, **params)
+      config = LedgerSync::Domains::Configuration.new(*args, **params)
+      yield(config) if block_given?
+
+      domains.register_domain(config: config)
+    end
+
+    def self.register_main_domain
+      config = LedgerSync::Domains::Configuration.new(:main, base_module: nil)
+      config.name = 'Main'
+
+      domains.register_domain(config: config)
+    end
+  end
 end

--- a/lib/ledger_sync/domains/operation.rb
+++ b/lib/ledger_sync/domains/operation.rb
@@ -103,7 +103,7 @@ module LedgerSync
         def allowed?
           return true unless self.class.internal?
 
-          self.class.to_s.start_with?(@domain.to_s)
+          local_domain == @domain
         end
 
         def performed?
@@ -120,7 +120,17 @@ module LedgerSync
 
         def serializer_class_for(resource:)
           Object.const_get(
-            "#{resource.class.to_s.pluralize}::#{@domain.to_s.capitalize}Serializer"
+            "#{resource.class.to_s.pluralize}::#{domain}Serializer"
+          )
+        end
+
+        def domain
+          LedgerSync::Domains.domains.module_for(domain: @domain)
+        end
+
+        def local_domain
+          LedgerSync::Domains.domains.domain_for(
+            base_module: self.class.to_s.split('::').first.constantize
           )
         end
 

--- a/lib/ledger_sync/domains/operation.rb
+++ b/lib/ledger_sync/domains/operation.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
-# reopen AR module for non-rails apps
-module ActiveRecord
-  module Base; end
+unless Object.const_defined?('ActiveRecord')
+  # reopen AR module for non-rails apps
+  module ActiveRecord
+    module Base; end
+  end
 end
 
 module LedgerSync
   module Domains
+    class InternalOperationError < LedgerSync::Error::OperationError; end
+
     class Operation
       class OperationResult
         module ResultTypeBase
@@ -28,10 +32,23 @@ module LedgerSync
       end
 
       module Mixin # rubocop:disable Metrics/ModuleLength
+        module ClassMethods
+          @internal = false
+
+          def internal
+            @internal = true
+          end
+
+          def internal?
+            !!@internal
+          end
+        end
+
         def self.included(base)
           base.include SimplySerializable::Mixin
           base.include Fingerprintable::Mixin
           base.include LedgerSync::Error::HelpersMixin
+          base.extend ClassMethods
 
           base.class_eval do
             simply_serialize only: %i[
@@ -50,6 +67,15 @@ module LedgerSync
         end
 
         def perform # rubocop:disable Metrics/MethodLength
+          unless allowed?
+            return failure(
+              LedgerSync::Domains::InternalOperationError.new(
+                operation: self,
+                message: 'Cross-domain operation execution is not allowed'
+              )
+            )
+          end
+
           if performed?
             return failure(
               LedgerSync::Error::OperationError::PerformedOperationError.new(
@@ -72,6 +98,12 @@ module LedgerSync
           ensure
             @performed = true
           end
+        end
+
+        def allowed?
+          return true unless self.class.internal?
+
+          self.class.to_s.start_with?(@domain.to_s)
         end
 
         def performed?

--- a/lib/ledger_sync/domains/store.rb
+++ b/lib/ledger_sync/domains/store.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module LedgerSync
+  module Domains
+    class ConfigurationStore
+      attr_reader :configs
+
+      def initialize
+        @configs = {}
+      end
+
+      def register_domain(config:)
+        @configs[config.root_key] = config
+      end
+
+      def module_for(domain:)
+        @configs[domain]&.base_module
+      end
+
+      def domain_for(base_module:)
+        config = @configs.values.find { |c| c.base_module == base_module }
+        config ||= @configs[:main]
+
+        config.root_key
+      end
+    end
+
+    class Configuration
+      attr_accessor :name
+      attr_reader :root_key, :base_module
+
+      def initialize(root_key, base_module:)
+        @root_key = root_key.to_sym
+        @name = root_key.to_s.capitalize
+        @base_module = base_module
+      end
+    end
+  end
+end

--- a/spec/ledger_sync/operation_spec.rb
+++ b/spec/ledger_sync/operation_spec.rb
@@ -9,6 +9,8 @@ class TestResource < LedgerSync::Resource
 end
 
 class TestOperation < LedgerSync::Domains::Operation::Find
+  internal
+
   def resource
     return nil if params[:id].negative?
 
@@ -54,6 +56,32 @@ RSpec.describe LedgerSync::Domains::Operation do
 
       it 'fails' do
         expect(operation.success?).to eq(false)
+      end
+    end
+
+    context 'internal operation' do
+      context 'called from same domain' do
+        let(:operation) { TestOperation.new(id: 1, limit: {}, domain: 'Test') }
+
+        before {
+          operation.perform
+        }
+  
+        it 'succeeds' do
+          expect(operation.success?).to eq(true)
+        end
+      end
+
+      context 'called from wrong domain' do
+        let(:operation) { TestOperation.new(id: 1, limit: {}, domain: 'NotATest') }
+
+        before {
+          operation.perform
+        }
+  
+        it 'fails' do
+          expect(operation.success?).to eq(false)
+        end  
       end
     end
   end

--- a/spec/ledger_sync/operation_spec.rb
+++ b/spec/ledger_sync/operation_spec.rb
@@ -2,6 +2,9 @@
 
 require 'spec_helper'
 
+LedgerSync::Domains.register_main_domain
+LedgerSync::Domains.register_domain(:wrong, base_module: nil)
+
 class TestResource < LedgerSync::Resource
   attribute :name, type: LedgerSync::Type::String
   attribute :phone_number, type: LedgerSync::Type::String
@@ -19,7 +22,7 @@ class TestOperation < LedgerSync::Domains::Operation::Find
 end
 
 module TestResources
-  class TestSerializer < LedgerSync::Domains::Serializer
+  class Serializer < LedgerSync::Domains::Serializer
     attribute :name
     attribute :phone_number
     attribute :email, if: :email_present?
@@ -35,7 +38,7 @@ end
 RSpec.describe LedgerSync::Domains::Operation do
   describe 'operate' do
     context 'with nice ID' do
-      let(:operation) { TestOperation.new(id: 1, limit: {}, domain: 'Test') }
+      let(:operation) { TestOperation.new(id: 1, limit: {}, domain: :main) }
 
       before {
         operation.perform
@@ -48,7 +51,7 @@ RSpec.describe LedgerSync::Domains::Operation do
     end
 
     context 'with bad ID' do
-      let(:operation) { TestOperation.new(id: -1, limit: {}, domain: 'Test') }
+      let(:operation) { TestOperation.new(id: -1, limit: {}, domain: :main) }
 
       before {
         operation.perform
@@ -61,7 +64,7 @@ RSpec.describe LedgerSync::Domains::Operation do
 
     context 'internal operation' do
       context 'called from same domain' do
-        let(:operation) { TestOperation.new(id: 1, limit: {}, domain: 'Test') }
+        let(:operation) { TestOperation.new(id: 1, limit: {}, domain: :main) }
 
         before {
           operation.perform
@@ -73,7 +76,7 @@ RSpec.describe LedgerSync::Domains::Operation do
       end
 
       context 'called from wrong domain' do
-        let(:operation) { TestOperation.new(id: 1, limit: {}, domain: 'NotATest') }
+        let(:operation) { TestOperation.new(id: 1, limit: {}, domain: :wrong) }
 
         before {
           operation.perform
@@ -81,7 +84,7 @@ RSpec.describe LedgerSync::Domains::Operation do
   
         it 'fails' do
           expect(operation.success?).to eq(false)
-        end  
+        end
       end
     end
   end


### PR DESCRIPTION
More context: https://public.3.basecamp.com/p/ZmTv4mzgTrpgy3thJW4zTKVn

Sometimes you just want to write an operation that is useful for local domain. Ruby doesnt prevent this class/operation from being accessed from anywhere.

Use `internal` flag when defining operation to _flag_ it as internal. If other `domain` is passed into the operation then the one where operation has been defined, performing the operation will return failure.